### PR TITLE
relax version constraints to allow use on php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,10 @@
         "source": "https://github.com/kvz/youtube-id"
     },
     "require": {
-        "php": "^7.0"
+        "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.5.*",
+        "phpunit/phpunit": ">=7.5",
         "friendsofphp/php-cs-fixer": "^2.14"
     },
     "autoload": {


### PR DESCRIPTION
I wanted to use this in a php8 environment, these changes allowed me to do so.

Here's the test results.

```
[jon@Jonny-PC youtube-id]$ vendor/bin/phpunit --bootstrap vendor/autoload.php tests/ConverterTest.php
PHPUnit 9.5.25 #StandWithUkraine

..........                                                        10 / 10 (100%)

Time: 00:00.004, Memory: 4.00 MB

OK (10 tests, 15 assertions)
```
